### PR TITLE
Add a workflow to run the profiler on multiple OSs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,4 +33,4 @@ jobs:
     - name: Profile
       run: |
         cd build
-        ls
+        ./ProfilerExamples

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,13 +30,7 @@ jobs:
         cd build 
         cmake --build .
         
-    - name: Test
+    - name: Profile
       run: |
         cd build
-        ctest 
-        
-    - name: Benchmark
-      run: |
-        cd build
-        ./likelihoods_benchmark.exe
-        ./model_benchmark.exe
+        ls

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,42 @@
+on:
+  push:
+    branches:
+      - main
+      
+defaults:
+  run:
+    working-directory: ./examples
+
+name: EmbeddedProfiler
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: seanmiddleditch/gha-setup-ninja@master # https://github.com/seanmiddleditch/gha-setup-ninja
+
+    - name: Configure
+      run: |
+        cmake -S . -B build -G"Ninja"
+        
+    - name: Build
+      run: |
+        cd build 
+        cmake --build .
+        
+    - name: Test
+      run: |
+        cd build
+        ctest 
+        
+    - name: Benchmark
+      run: |
+        cd build
+        ./likelihoods_benchmark.exe
+        ./model_benchmark.exe

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.10)
+
+# set the project name
+project(EmbeddedProfiler)
+
+# add the executable
+add_executable(ProfilerExamples main.cpp)

--- a/examples/main.cpp
+++ b/examples/main.cpp
@@ -15,7 +15,7 @@
 #include <iostream>
 #include <thread>
 #include <chrono>
-#include "Profiler.hpp"
+#include "../include/Profiler.hpp"
 using namespace std;
 
 void DoStuff1() {


### PR DESCRIPTION
This pull request addresses issue #1 and includes following changes:

- In `examples/main.cpp`, I updated `#include "Profiler.hpp"` to `#include "../include/Profiler.hpp"` based on an error I received when testing the code on Windows: `No such file or directory #include "Profiler.hpp"`
- I added a workflow yaml file to run the code on multiple operating systems 

Remaining issues:
- The workflow works fine on MacOS, however, it fails to run on Windows and Ubuntu. Please check the errors under `Build` section of the GitHub Actions workflow log.
- I have not figured out how to use one line of code to run binary executables on different operating systems. I am thinking about using if statement to run executables one by one, but please let me know if you have some suggestions. 

Please feel free to squash the commits when merging the pull request and let me know if you have any questions. Thanks!